### PR TITLE
Fix getTokenFromCommunityAPI without Realt Community Token

### DIFF
--- a/pages/api/properties/[chainId].ts
+++ b/pages/api/properties/[chainId].ts
@@ -4,11 +4,14 @@ import { getWhitelistedProperties } from "src/utils/properties";
 
 const getTokenFromCommunityAPI = new Promise<APIPropertiesToken[]>( async (resolve, reject) => {
     try{
+        const headers: {[key: string]: any} = {};
+        if (process.env.COMMUNITY_API_KEY !== undefined) {
+            headers["X-AUTH-REALT-TOKEN"] = process.env.COMMUNITY_API_KEY;
+        }
+
         const response = await fetch("https://api.realt.community/v1/token",{
             method: "GET",
-            headers: {
-                "X-AUTH-REALT-TOKEN": process.env.COMMUNITY_API_KEY ?? ""
-            }
+            headers: headers
         });
 
         if(response.ok){


### PR DESCRIPTION
Greetings.

I went accross your repository and quickly took on setting it up on my local machine, which is pretty straightforward.

I then asked for a community api key as described in the `README.md` file and while I was waiting for it (I submitted a Google Form somewhere from a Telegram group) I figured that I could use the API without specifying any key nor providing the `X-Auth-Realt-Token` header as one can see here: https://api.realt.community/

I am not sure whether this is wanted/temporary or not, but I figured that it could help people gain some time while trying to contribute on this project.

Let me know what you think about it. 😊 